### PR TITLE
Update TradeListeners.java

### DIFF
--- a/src/main/java/com/artillexstudios/axtrade/listeners/TradeListeners.java
+++ b/src/main/java/com/artillexstudios/axtrade/listeners/TradeListeners.java
@@ -74,6 +74,7 @@ public class TradeListeners implements Listener {
         final Player player = event.getPlayer();
         final Trade trade = Trades.getTrade(player);
         if (trade == null) return;
+        if (System.currentTimeMillis() - trade.getPrepTime() < 1_000L) return;
         if (event.getFrom().distanceSquared(event.getTo()) == 0) return;
         trade.abort();
     }


### PR DESCRIPTION
Fix trade cancellation bug by adding a delay check to prevent immediate trade abort when the sender moves during trade acceptance.