### PR TITLE
Drop trade items if they don't fit

### DIFF
--- a/src/main/java/com/artillexstudios/axtrade/trade/Trade.java
+++ b/src/main/java/com/artillexstudios/axtrade/trade/Trade.java
@@ -64,11 +64,15 @@ public class Trade {
         end();
         player1.getTradeGui().getItems(false).forEach(itemStack -> {
             if (itemStack == null) return;
-            player1.getPlayer().getInventory().addItem(itemStack);
+            player1.getPlayer().getInventory().addItem(itemStack).values().forEach(item -> {
+                player1.getPlayer().getWorld().dropItem(player1.getPlayer().getEyeLocation(), item);
+            });
         });
         player2.getTradeGui().getItems(false).forEach(itemStack -> {
             if (itemStack == null) return;
-            player2.getPlayer().getInventory().addItem(itemStack);
+            player2.getPlayer().getInventory().addItem(itemStack).values().forEach(item -> {
+                player2.getPlayer().getWorld().dropItem(player2.getPlayer().getEyeLocation(), item);
+            });
         });
         HistoryUtils.writeToHistory(String.format("Aborted: %s - %s", player1.getPlayer().getName(), player2.getPlayer().getName()));
         MESSAGEUTILS.sendLang(player1.getPlayer(), "trade.aborted", Map.of("%player%", player2.getPlayer().getName()));

--- a/src/main/java/com/artillexstudios/axtrade/trade/TradeGui.java
+++ b/src/main/java/com/artillexstudios/axtrade/trade/TradeGui.java
@@ -179,7 +179,9 @@ public class TradeGui extends GuiFrame {
         if (!slots.contains(event.getSlot())) {
             event.setCancelled(true);
             if (event.getCursor() == null) return;
-            player.getPlayer().getInventory().addItem(event.getCursor().clone());
+            player.getPlayer().getInventory().addItem(event.getCursor().clone()).values().forEach(item -> {
+                player.getPlayer().getWorld().dropItem(player.getPlayer().getEyeLocation(), item);
+            });
             event.getCursor().setAmount(0);
             return;
         }


### PR DESCRIPTION
Players can run out of inventory space and won't receive items in some cases. This PR adds fallbacks to inventory addItem calls to make sure items aren't accidentally destroyed