### PR TITLE
Update PlaceholderCurrencyHook.java

### DIFF
--- a/src/main/java/com/artillexstudios/axtrade/hooks/currency/PlaceholderCurrencyHook.java
+++ b/src/main/java/com/artillexstudios/axtrade/hooks/currency/PlaceholderCurrencyHook.java
@@ -23,7 +23,7 @@ public class PlaceholderCurrencyHook implements CurrencyHook {
 
     @Override
     public void setup() {
-        df = new DecimalFormat("#");
+        df = new DecimalFormat("#.##");
     }
 
     @Override


### PR DESCRIPTION
Fix conversion to integers when `uses-double: true` in currencies.yml for placeholder-currencies.

Currently, even with `uses-double: true`, the commands under settings will only give/take integer amounts. After this change, commands will give/take amounts up to two decimals.