### PR TITLE
Feat/prevent vanished trading

### DIFF
--- a/src/main/java/com/artillexstudios/axtrade/listeners/EntityInteractListener.java
+++ b/src/main/java/com/artillexstudios/axtrade/listeners/EntityInteractListener.java
@@ -23,6 +23,7 @@ public class EntityInteractListener implements Listener {
         if (!player.isSneaking()) return;
         if (!(event.getRightClicked() instanceof Player sendTo)) return;
         if (!sendTo.isOnline()) return;
+        if (CONFIG.getBoolean("prevent-vanished-trading", true) && !sendTo.canSee(sendTo)) return;
 
         cooldown.addCooldown(player, 100L);
         Requests.addRequest(player, sendTo);

--- a/src/main/java/com/artillexstudios/axtrade/request/Requests.java
+++ b/src/main/java/com/artillexstudios/axtrade/request/Requests.java
@@ -55,6 +55,11 @@ public class Requests {
             return;
         }
 
+        if (CONFIG.getBoolean("prevent-vanished-trading", true) && (!sender.canSee(sender) || !receiver.canSee(receiver))) {
+            MESSAGEUTILS.sendLang(sender, "commands.invalid-player", replacements);
+            return;
+        }
+
         if (TOGGLED.getBoolean("toggled." + receiver.getUniqueId())) {
             MESSAGEUTILS.sendLang(sender, "request.not-accepting", replacements);
             return;

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -35,7 +35,7 @@ prevent-adding-items-when-inventory-full: true
 disallow-same-ip-trade: false
 
 # if enabled, vanished players cannot trade or be traded with
-prevent-vanished-trading: true
+prevent-vanished-trading: false
 
 number-formatting:
   # modes:

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -34,6 +34,9 @@ prevent-adding-items-when-inventory-full: true
 # if enabled, players will not be able to trade if they have the same ip address
 disallow-same-ip-trade: false
 
+# if enabled, vanished players cannot trade or be traded with
+prevent-vanished-trading: true
+
 number-formatting:
   # modes:
   # 0 - formatted (customizable, look at the formatted part)


### PR DESCRIPTION
Prevents trading with vanished players by treating them as offline.

- Added vanish detection using `player.canSee(player)`
- Prevents trade requests when either player is vanished
- Uses same error message as offline players: "The player [name] can not be found!"
- Configurable via `prevent-vanished-trading` option (default: false)
- Compatible with most vanish plugins