### PR TITLE
Fix Folia GUI scheduler usage

### DIFF
--- a/src/main/java/com/artillexstudios/axtrade/trade/Trade.java
+++ b/src/main/java/com/artillexstudios/axtrade/trade/Trade.java
@@ -13,7 +13,6 @@ import com.artillexstudios.axtrade.utils.Utils;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
-import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 
 import java.util.ArrayList;
@@ -41,16 +40,14 @@ public class Trade {
     }
 
     public void update() {
-        player1.getTradeGui().update();
-        player2.getTradeGui().update();
+        update(player1);
+        update(player2);
     }
 
     public void end() {
         ended = true;
-        player1.getPlayer().closeInventory();
-        player1.getPlayer().updateInventory();
-        player2.getPlayer().closeInventory();
-        player2.getPlayer().updateInventory();
+        closeInventory(player1);
+        closeInventory(player2);
     }
 
     public void abort() {
@@ -66,12 +63,12 @@ public class Trade {
         end();
         player1.getTradeGui().getItems(false).forEach(itemStack -> {
             if (itemStack == null) return;
-            addOrDrop(player1.getPlayer().getInventory(), List.of(itemStack), player1.getPlayer().getLocation());
+            addOrDrop(player1.getPlayer(), List.of(itemStack));
         });
         if (player2.getTradeGui() != null) {
             player2.getTradeGui().getItems(false).forEach(itemStack -> {
                 if (itemStack == null) return;
-                addOrDrop(player2.getPlayer().getInventory(), List.of(itemStack), player2.getPlayer().getLocation());
+                addOrDrop(player2.getPlayer(), List.of(itemStack));
             });
         }
         HistoryUtils.writeToHistory(String.format("Aborted: %s - %s", player1.getPlayer().getName(), player2.getPlayer().getName()));
@@ -174,7 +171,7 @@ public class Trade {
                 List<String> player1Items = new ArrayList<>();
                 player1.getTradeGui().getItems(false).forEach(itemStack -> {
                     if (itemStack == null) return;
-                    addOrDrop(player2.getPlayer().getInventory(), List.of(itemStack), player2.getPlayer().getLocation());
+                    addOrDrop(player2.getPlayer(), List.of(itemStack));
                     final String itemName = Utils.getFormattedItemName(itemStack);
                     int itemAm = itemStack.getAmount();
                     player1Items.add(itemAm + "x " + itemName);
@@ -187,7 +184,7 @@ public class Trade {
                 List<String> player2Items = new ArrayList<>();
                 player2.getTradeGui().getItems(false).forEach(itemStack -> {
                     if (itemStack == null) return;
-                    addOrDrop(player1.getPlayer().getInventory(), List.of(itemStack), player1.getPlayer().getLocation());
+                    addOrDrop(player1.getPlayer(), List.of(itemStack));
                     final String itemName = Utils.getFormattedItemName(itemStack);
                     int itemAm = itemStack.getAmount();
                     player2Items.add(itemAm + "x " + itemName);
@@ -233,13 +230,27 @@ public class Trade {
         return ended;
     }
 
-    private void addOrDrop(Inventory inventory, List<ItemStack> items, Location location) {
-        Location copy = location.clone();
-        Scheduler.get().runAt(copy, () -> {
+    private void update(TradePlayer tradePlayer) {
+        Scheduler.get().run(tradePlayer.getPlayer(), scheduledTask -> {
+            if (ended || tradePlayer.getTradeGui() == null) return;
+            tradePlayer.getTradeGui().update();
+        }, () -> {});
+    }
+
+    private void closeInventory(TradePlayer tradePlayer) {
+        Scheduler.get().run(tradePlayer.getPlayer(), scheduledTask -> {
+            tradePlayer.getPlayer().closeInventory();
+            tradePlayer.getPlayer().updateInventory();
+        }, () -> {});
+    }
+
+    private void addOrDrop(Player player, List<ItemStack> items) {
+        Scheduler.get().run(player, scheduledTask -> {
+            Location copy = player.getLocation().clone();
             for (ItemStack key : items) {
-                HashMap<Integer, ItemStack> remaining = inventory.addItem(key);
+                HashMap<Integer, ItemStack> remaining = player.getInventory().addItem(key);
                 remaining.forEach((k, v) -> copy.getWorld().dropItem(copy, v));
             }
-        });
+        }, () -> {});
     }
 }

--- a/src/main/java/com/artillexstudios/axtrade/trade/TradeGui.java
+++ b/src/main/java/com/artillexstudios/axtrade/trade/TradeGui.java
@@ -187,7 +187,7 @@ public class TradeGui extends GuiFrame {
         }
 
         player.cancel();
-        Scheduler.get().run(scheduledTask -> trade.update());
+        trade.update();
     }
 
     private void handleClickBottom(InventoryClickEvent event) {
@@ -215,7 +215,7 @@ public class TradeGui extends GuiFrame {
         }
 
         player.cancel();
-        Scheduler.get().run(scheduledTask -> trade.update());
+        trade.update();
     }
 
     private void handleDrag(InventoryDragEvent event) {
@@ -226,7 +226,7 @@ public class TradeGui extends GuiFrame {
             break;
         }
 
-        Scheduler.get().run(scheduledTask -> trade.update());
+        trade.update();
         if (ownInv) return;
 
         if (!new HashSet<>(slots).containsAll(event.getInventorySlots())) {
@@ -290,7 +290,7 @@ public class TradeGui extends GuiFrame {
                         break;
                 }
             }
-            Scheduler.get().run(scheduledTask -> {
+            Scheduler.get().run(player.getPlayer(), scheduledTask -> {
                 if (trade.isEnded()) return;
                 gui.open(player.getPlayer());
                 inSign = false;
@@ -298,7 +298,7 @@ public class TradeGui extends GuiFrame {
                 currentTitle = "";
                 player.cancel();
                 updateTitle();
-            });
+            }, () -> {});
         }).build(player.getPlayer());
         sign.open();
     }
@@ -319,7 +319,7 @@ public class TradeGui extends GuiFrame {
 
         shulkerGui.getInventory().setContents(ShulkerUtils.getStorageContents(event.getCurrentItem(), false).toArray(ItemStack[]::new));
         shulkerGui.setCloseGuiAction(e -> {
-            Scheduler.get().runLaterAt(player.getPlayer().getLocation(), () -> {
+            Scheduler.get().runLater(player.getPlayer(), scheduledTask -> {
                 if (trade.isEnded()) return;
                 trade.prepTime = System.currentTimeMillis();
                 gui.open(player.getPlayer());
@@ -327,7 +327,7 @@ public class TradeGui extends GuiFrame {
                 trade.update();
                 currentTitle = "";
                 updateTitle();
-            }, 1);
+            }, () -> {}, 1);
         });
         shulkerGui.open(player.getPlayer());
     }
@@ -367,11 +367,11 @@ public class TradeGui extends GuiFrame {
         if (currentTitle.equals(newTitle)) return;
         this.currentTitle = newTitle;
 
-        Scheduler.get().runLater(task -> {
+        Scheduler.get().runLater(player.getPlayer(), task -> {
             Inventory topInv = player.getPlayer().getOpenInventory().getTopInventory();
             if (topInv.equals(gui.getInventory())) {
                 NMSHandlers.getNmsHandler().setTitle(player.getPlayer().getOpenInventory().getTopInventory(), StringUtils.format(newTitle));
             }
-        }, 1);
+        }, () -> {}, 1);
     }
 }


### PR DESCRIPTION
## What changed

- Schedule trade GUI updates, inventory closing, and inventory item returns on the relevant player entity scheduler.
- Reopen the trade GUI after sign input and shulker preview using player-bound scheduler calls instead of global/region scheduler calls.
- Update GUI titles through the player entity scheduler.

## Why

Canvas/Folia reports unsafe calls when player menu operations are executed from the global or region scheduler. The reported stack traces showed `openInventory` and `closeInventory` running from Folia scheduler threads that do not own the player entity. Player inventory and menu operations need to run on that player's entity scheduler.

## Impact

This should prevent Canvas/Folia warnings such as `Cannot init menu async` and `Cannot close container async` during trade GUI reopen/close flows, while keeping the plugin compiled against the existing AxAPI scheduler wrapper.

## Validation

- `git diff --check` passed for the changed files.
- `mvn -q -DskipTests package` could not reach compilation in this checkout because required `systemPath` jars under `libs/` are missing and `me.TechsCode:UltraEconomyAPI:2.6.4` is not currently resolvable from configured repositories.
