### PR TITLE
Add built-in language-specific message and GUI configs

### DIFF
--- a/src/main/java/com/artillexstudios/axtrade/AxTrade.java
+++ b/src/main/java/com/artillexstudios/axtrade/AxTrade.java
@@ -25,6 +25,10 @@ import org.bstats.bukkit.Metrics;
 import org.bukkit.Bukkit;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.util.Locale;
 
 public final class AxTrade extends AxPlugin {
     public static Config CONFIG;
@@ -51,14 +55,11 @@ public final class AxTrade extends AxPlugin {
         new Metrics(this, 21500);
 
         CONFIG = new Config(new File(getDataFolder(), "config.yml"), getResource("config.yml"), GeneralSettings.builder().setUseDefaults(false).build(), LoaderSettings.builder().setAutoUpdate(true).build(), DumperSettings.DEFAULT, UpdaterSettings.builder().setKeepAll(true).setVersioning(new BasicVersioning("version")).build());
-        GUIS = new Config(new File(getDataFolder(), "guis.yml"), getResource("guis.yml"), GeneralSettings.builder().setUseDefaults(false).build(), LoaderSettings.builder().setAutoUpdate(true).build(), DumperSettings.DEFAULT, UpdaterSettings.builder().setKeepAll(true).setVersioning(new BasicVersioning("version")).build());
-        LANG = new Config(new File(getDataFolder(), "lang.yml"), getResource("lang.yml"), GeneralSettings.builder().setUseDefaults(false).build(), LoaderSettings.builder().setAutoUpdate(true).build(), DumperSettings.DEFAULT, UpdaterSettings.builder().setKeepAll(true).setVersioning(new BasicVersioning("version")).build());
+        loadLanguageConfigs();
         HOOKS = new Config(new File(getDataFolder(), "currencies.yml"), getResource("currencies.yml"), GeneralSettings.builder().setUseDefaults(false).build(), LoaderSettings.builder().setAutoUpdate(true).build(), DumperSettings.DEFAULT, UpdaterSettings.builder().setKeepAll(true).setVersioning(new BasicVersioning("version")).build());
         TOGGLED = new Config(new File(getDataFolder(), "toggled.yml"), getResource("toggled.yml"), GeneralSettings.builder().setUseDefaults(false).build(), LoaderSettings.DEFAULT, DumperSettings.DEFAULT, UpdaterSettings.DEFAULT);
 
         LanguageManager.reload();
-
-        MESSAGEUTILS = new MessageUtils(LANG.getBackingDocument(), "prefix", CONFIG.getBackingDocument());
 
         threadedQueue = new ThreadedQueue<>("AxTrade-Datastore-thread");
 
@@ -92,5 +93,62 @@ public final class AxTrade extends AxPlugin {
         FeatureFlags.PLACEHOLDER_API_HOOK.set(true);
         FeatureFlags.PLACEHOLDER_API_IDENTIFIER.set("axtrade");
         FeatureFlags.ENABLE_PACKET_LISTENERS.set(true);
+    }
+
+    public static void loadLanguageConfigs() {
+        final AxTrade plugin = (AxTrade) instance;
+        GUIS = plugin.createLanguageConfig("guis.yml");
+        LANG = plugin.createLanguageConfig("lang.yml");
+        MESSAGEUTILS = new MessageUtils(LANG.getBackingDocument(), "prefix", CONFIG.getBackingDocument());
+    }
+
+    private Config createLanguageConfig(String resourceName) {
+        final File file = getLanguageFile(resourceName);
+        migrateLegacyLanguageFile(resourceName, file);
+        ensureLanguageDirectory(file);
+        return new Config(file, getLanguageResource(resourceName), GeneralSettings.builder().setUseDefaults(false).build(), LoaderSettings.builder().setAutoUpdate(true).build(), DumperSettings.DEFAULT, UpdaterSettings.builder().setKeepAll(true).setVersioning(new BasicVersioning("version")).build());
+    }
+
+    private File getLanguageFile(String resourceName) {
+        return new File(getDataFolder(), "lang/" + getConfiguredLanguageKey() + "/" + resourceName);
+    }
+
+    private InputStream getLanguageResource(String resourceName) {
+        final InputStream languageResource = getResource("lang/" + getConfiguredLanguageKey() + "/" + resourceName);
+        return languageResource == null ? getResource(resourceName) : languageResource;
+    }
+
+    private void migrateLegacyLanguageFile(String resourceName, File targetFile) {
+        if (!getConfiguredLanguageKey().equals("en_us") || targetFile.exists()) return;
+
+        final File legacyFile = new File(getDataFolder(), resourceName);
+        if (!legacyFile.exists()) return;
+
+        try {
+            Files.createDirectories(targetFile.toPath().getParent());
+            Files.copy(legacyFile.toPath(), targetFile.toPath());
+        } catch (IOException exception) {
+            getLogger().warning("Failed to migrate " + resourceName + " to " + targetFile.getPath() + ": " + exception.getMessage());
+        }
+    }
+
+    private void ensureLanguageDirectory(File file) {
+        try {
+            Files.createDirectories(file.toPath().getParent());
+        } catch (IOException exception) {
+            getLogger().warning("Failed to create language directory for " + file.getPath() + ": " + exception.getMessage());
+        }
+    }
+
+    private static String getConfiguredLanguageKey() {
+        if (CONFIG == null) return "en_us";
+        return CONFIG.getString("language", "en_US").toLowerCase(Locale.ROOT).replace('-', '_');
+    }
+
+    public static Locale getConfiguredLocale() {
+        if (CONFIG == null) return Locale.US;
+
+        final Locale locale = Locale.forLanguageTag(getConfiguredLanguageKey().replace('_', '-'));
+        return locale.toLanguageTag().equals("und") ? Locale.US : locale;
     }
 }

--- a/src/main/java/com/artillexstudios/axtrade/commands/CommandManager.java
+++ b/src/main/java/com/artillexstudios/axtrade/commands/CommandManager.java
@@ -6,7 +6,6 @@ import revxrsal.commands.bukkit.BukkitCommandHandler;
 import revxrsal.commands.orphan.Orphans;
 
 import java.util.List;
-import java.util.Locale;
 
 import static com.artillexstudios.axtrade.AxTrade.CONFIG;
 
@@ -17,13 +16,14 @@ public class CommandManager {
         handler = BukkitCommandHandler.create(AxTrade.getInstance());
 
         handler.getTranslator().add(new CommandMessages());
-        handler.setLocale(Locale.of("en", "US"));
+        handler.setLocale(AxTrade.getConfiguredLocale());
 
         reload();
     }
 
     public static void reload() {
         handler.unregisterAllCommands();
+        handler.setLocale(AxTrade.getConfiguredLocale());
 
         List<String> aliases = CONFIG.getStringList("command-aliases");
         if (!aliases.isEmpty()) {

--- a/src/main/java/com/artillexstudios/axtrade/commands/subcommands/Reload.java
+++ b/src/main/java/com/artillexstudios/axtrade/commands/subcommands/Reload.java
@@ -1,9 +1,12 @@
 package com.artillexstudios.axtrade.commands.subcommands;
 
 import com.artillexstudios.axapi.utils.StringUtils;
+import com.artillexstudios.axtrade.AxTrade;
+import com.artillexstudios.axtrade.commands.CommandManager;
 import com.artillexstudios.axtrade.hooks.HookManager;
 import com.artillexstudios.axtrade.lang.LanguageManager;
 import com.artillexstudios.axtrade.utils.NumberUtils;
+import com.artillexstudios.axtrade.utils.UpdateNotifier;
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 
@@ -26,6 +29,7 @@ public enum Reload {
         }
         Bukkit.getConsoleSender().sendMessage(StringUtils.formatToString("&#00FFDD╠ &#AAFFDDReloaded &fconfig.yml&#AAFFDD!"));
 
+        AxTrade.loadLanguageConfigs();
         if (!LANG.reload()) {
             MESSAGEUTILS.sendLang(sender, "reload.failed", Map.of("%file%", "lang.yml"));
             return;
@@ -48,6 +52,8 @@ public enum Reload {
 
         HookManager.updateHooks();
         NumberUtils.reload();
+        CommandManager.reload();
+        UpdateNotifier.init(CONFIG, LANG);
 
         Bukkit.getConsoleSender().sendMessage(StringUtils.formatToString("&#00FFDD╚ &#AAFFDDSuccessful reload!"));
         MESSAGEUTILS.sendLang(sender, "reload.success");

--- a/src/main/java/com/artillexstudios/axtrade/utils/CommandMessages.java
+++ b/src/main/java/com/artillexstudios/axtrade/utils/CommandMessages.java
@@ -1,6 +1,7 @@
 package com.artillexstudios.axtrade.utils;
 
 import com.artillexstudios.axapi.utils.StringUtils;
+import com.artillexstudios.axtrade.AxTrade;
 import revxrsal.commands.locales.LocaleReader;
 
 import java.util.Locale;
@@ -64,10 +65,8 @@ public class CommandMessages implements LocaleReader {
         return StringUtils.formatToString(CONFIG.getString("prefix", "") + res);
     }
 
-    private final Locale locale = new Locale("en", "US");
-
     @Override
     public Locale getLocale() {
-        return locale;
+        return AxTrade.getConfiguredLocale();
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -4,6 +4,8 @@ prefix: "<gradient:#00FFDD:#55FFFF><b>AxTrade</b></gradient> &7» "
 
 # format: language_COUNTRY
 # after changing this, the server will download the default item names
+# built-in languages: en_US, zh_CN
+# message/gui files are stored in the lang/<language>/ folder
 language: en_US
 
 # you must define at least 1

--- a/src/main/resources/lang/en_us/guis.yml
+++ b/src/main/resources/lang/en_us/guis.yml
@@ -1,0 +1,144 @@
+# DOCUMENTATION: https://docs.artillex-studios.com/axtrade.html
+# ITEM BUILDER: https://docs.artillex-studios.com/item-builder.html
+
+# ----- SETTINGS -----
+
+title: "&0Trading with: %player%"
+# a gui can have 1-6 rows
+rows: 6
+
+# ----- SLOTS -----
+
+# the slots where the items can be placed
+# make sure to not put decorative items or currency items in the these slots
+# the own-slots and partner-slots must have an equal amount of slots
+own-slots:
+  - 9-12
+  - 18-21
+  - 27-30
+  - 36-39
+  - 45-48
+
+partner-slots:
+  - 14-17
+  - 23-26
+  - 32-35
+  - 41-44
+  - 50-53
+
+# ----- ITEMS -----
+
+# items on your side
+own:
+  confirm-item:
+    slot: 0
+    # you can use these placeholders:
+    # %own-name%"
+    # %partner-name%
+    accept:
+      material: "RED_CONCRETE"
+      # if you want, you can add head textures, like this:
+      #material: "PLAYER_HEAD"
+      #texture: "%own-head%"
+      name: "&#00ffdd&lᴀᴄᴄᴇᴘᴛ ᴛʀᴀᴅᴇ"
+      lore:
+        - ""
+        - " &7- &fAre you happy with the trade?"
+        - ""
+        - "&#00ffdd&l> &#00ffddClick &8- &#00ffddConfirm Trade"
+    cancel:
+      material: "LIME_CONCRETE"
+      name: "&#00ffdd&lᴄᴀɴᴄᴇʟ ᴄᴏɴғɪʀᴍᴀᴛɪᴏɴ"
+      lore:
+        - ""
+        - " &7- &fDo you want to change something?"
+        - ""
+        - "&#00ffdd&l> &#00ffddClick &8- &#00ffddCancel Confirmation"
+  # you can define as many currencies as you want, but make sure to copy them to the 'partner' section too!
+  currency1:
+    slot: 2
+    # you need Vault installed for this
+    currency: "Vault"
+    material: "GOLD_NUGGET"
+    name: "&#00ffdd&lᴍᴏɴᴇʏ"
+    # you can use these placeholders:
+    #  %amount% (the amount the player set)
+    #  %tax-amount% (amount after tax)
+    #  %tax-percent% (the % of tax on the currency)
+    #  %tax-fee% (amount taken because of tax)
+    lore:
+      - "&7Your offer"
+      - ""
+      - " &7- &fAmount: &#00ffdd%amount%$"
+      - ""
+      - "&#00ffdd&l> &#00ffddClick &8- &#00ffddChange Amount"
+  currency2:
+    slot: 3
+    currency: "Experience"
+    material: "EXPERIENCE_BOTTLE"
+    name: "&#00ffdd&lᴇxᴘᴇʀɪᴇɴᴄᴇ"
+    lore:
+      - "&7Your offer"
+      - ""
+      - " &7- &fAmount: &#00ffdd%amount% EXP"
+      - ""
+      - "&#00ffdd&l> &#00ffddClick &8- &#00ffddChange Amount"
+
+# items on your trade partner's side
+partner:
+  confirm-item:
+    slot: 8
+    # you can also use these placeholders:
+    # %own-name%"
+    # %partner-name%
+    accept:
+      material: "RED_CONCRETE"
+      # if you want, you can add head textures, like this:
+      #material: "PLAYER_HEAD"
+      #texture: "%partner-head%"
+      name: "&#00ffdd&lᴡᴀɪᴛɪɴɢ ғᴏʀ ᴏᴛʜᴇʀ ᴘʟᴀʏᴇʀ"
+      lore:
+        - ""
+        - " &7- &f%partner-name% has not yet confirmed the trade!"
+        - ""
+    cancel:
+      material: "LIME_CONCRETE"
+      name: "&#00ffdd&lᴡᴀɪᴛɪɴɢ"
+      lore:
+        - ""
+        - " &7- &f%partner-name% has confirmed the trade!"
+  currency1:
+    slot: 6
+    currency: "Vault"
+    material: "GOLD_NUGGET"
+    name: "&#00ffdd&lᴍᴏɴᴇʏ"
+    # you can use these placeholders:
+    #  %amount% (the amount the player set)
+    #  %tax-amount% (amount after tax)
+    #  %tax-percent% (the % of tax on the currency)
+    #  %tax-fee% (amount taken because of tax)
+    lore:
+      - "&7%partner-name%'s offer"
+      - ""
+      - " &7- &fAmount: &#00ffdd%amount%$"
+      - ""
+      - "&#00ffdd&l> &#00ffddClick &8- &#00ffddChange Amount"
+  currency2:
+    slot: 5
+    currency: "Experience"
+    material: "EXPERIENCE_BOTTLE"
+    name: "&#00ffdd&lᴇxᴘᴇʀɪᴇɴᴄᴇ"
+    lore:
+      - "&7%partner-name%'s offer"
+      - ""
+      - " &7- &fAmount: &#00ffdd%amount% EXP"
+      - ""
+      - "&#00ffdd&l> &#00ffddClick &8- &#00ffddChange Amount"
+
+decoration-example:
+  slot: [4, 13, 22, 31, 40, 49]
+  material: "LIGHT_BLUE_STAINED_GLASS_PANE"
+  name: " "
+
+# do not change this
+version: 1

--- a/src/main/resources/lang/en_us/lang.yml
+++ b/src/main/resources/lang/en_us/lang.yml
@@ -1,0 +1,119 @@
+# DOCUMENTATION: https://docs.artillex-studios.com/axtrade.html
+
+player-help:
+  - " "
+  - "<gradient:#00FFDD:#55FFFF><b>AxTrade</b></gradient> <#22FFDD>Help"
+  - " <#22FFDD>➤ <white>/axtrade <player> <#DDDDDD>| <#77FFFF>Send trade request"
+  - " <#22FFDD>➤ <white>/axtrade accept <player> <#DDDDDD>| <#77FFFF>Accept trade request"
+  - " <#22FFDD>➤ <white>/axtrade deny <player> <#DDDDDD>| <#77FFFF>Deny trade request"
+  - " "
+
+admin-help:
+  - " "
+  - "<gradient:#00FFDD:#55FFFF><b>AxTrade</b></gradient> <#22FFDD>Help"
+  - " <#22FFDD>➤ <white>/axtrade <player> <#DDDDDD>| <#77FFFF>Send trade request"
+  - " <#22FFDD>➤ <white>/axtrade accept <player> <#DDDDDD>| <#77FFFF>Accept trade request"
+  - " <#22FFDD>➤ <white>/axtrade deny <player> <#DDDDDD>| <#77FFFF>Deny trade request"
+  - " <#22FFDD>➤ <white>/axtrade reload <#DDDDDD>| <#77FFFF>Reload plugin"
+  - " <#22FFDD>➤ <white>/axtrade force <player> <#DDDDDD>| <#77FFFF>Force start a trade"
+  - " <#22FFDD>➤ <white>/axtrade preview <#DDDDDD>| <#77FFFF>Opens read only gui (meant for testing)"
+  - " "
+
+reload:
+  success: "&#33FF33Plugin successfully reloaded!"
+  failed: "&#FF3333Failed to reload the plugin! Something is wrong in the &f%file%&#FF3333 file, look in the console or use a yaml validator to fix the errors!"
+
+trade:
+  started: "&#CCFFEEYou have started a trade with &#00FFDD%player%&#CCFFEE!"
+  completed: "&#CCFFEEYour trade with &#00FFDD%player% &#CCFFEEwas completed!"
+  aborted: "&#CCFFEEYour trade with &#00FFDD%player% &#CCFFEEwas aborted!"
+  blacklisted-item: "&#CCFFEEThis item is blacklisted!"
+  inventory-full: "&#CCFFEEYou can't put any more items in the gui, because your trade partner has no more empty slots."
+  preview-info: "&#CCFFEEYou are opening the preview gui, this is meant for testing your configuration, clicking buttons will cause errors and might not work."
+
+toggle:
+  enabled: "&#CCFFEEYou have enabled trade requests!"
+  disabled: "&#CCFFEEYou have disabled trade requests!"
+
+# summary after a successful trade
+summary:
+  get:
+    item: "&#00FF00&l+ &#00FF00%amount%x %item%"
+    currency: "&#00FF00&l+ &#00FF00%amount% %currency%"
+  give:
+    item: "&#FF0000&l- &#FF0000%amount%x %item%"
+    currency: "&#FF0000&l- &#FF0000%amount% %currency%"
+
+currency-editor:
+  success: "&#CCFFEESuccessfully changed value!"
+  failed: "&#CCFFEEIncorrect value!"
+  not-enough: "&#CCFFEEYou don't have enough of this currency!"
+
+request:
+  sent-sender: "&#CCFFEEYou have successfully sent a trade request to &#00FFDD%player%&#CCFFEE!"
+  sent-receiver:
+    info: "&#CCFFEEYou have received a trade request from &#00FFDD%player%&#CCFFEE!"
+    accept:
+      message: "&#00FF00/trade accept %player%"
+      hover: "&#00FF00Click here to &naccept&#00FF00 trade request!"
+    deny:
+      message: "&#FF0000/trade deny %player%"
+      hover: "&#FF0000Click here to &ndeny&#FF0000 trade request!"
+  no-request: "&#CCFFEEYou don't have an active trade request from &#00FFDD%player%&#CCFFEE!"
+  deny-sender: "&#CCFFEEYou trade request was denied by &#00FFDD%player%&#CCFFEE!"
+  deny-receiver: "&#CCFFEEYou have successfully denied &#00FFDD%player%&#CCFFEE's trade request!"
+  cant-trade-self: "&#CCFFEEYou can't send a trade request to yourself!"
+  already-in-trade: "&#CCFFEEThe player is already trading with someone!"
+  already-sent: "&#CCFFEEYou have already sent a trade request to &#00FFDD%player% &#CCFFEErecently!"
+  too-far: "&#CCFFEEYou are too far from &#00FFDD%player% &#CCFFEEto send a trade request!"
+  not-accepting: "&#CCFFEEThis player is not accepting trades!"
+  disallowed-gamemode: "&#CCFFEEEither you or the other player is in a disallowed gamemode!"
+  same-ip: "&#CCFFEEYou can't trade with an account that has the same ip as you!"
+  below-required-amount: "&#CCFFEEYou are required to trade at least &f%amount% %currency%&#CCFFEE!"
+  blacklisted-world: "&#CCFFEETrades are disabled in this world!"
+  expired: "&#CCFFEEYour trade request to &#00FFDD%player% &#CCFFEEhas expired!"
+  disabled-trading: "&#CCFFEEYou have disabled trades! Use &#00FFDD/trade toggle &#CCFFEEto enable."
+
+# this must be 4 lines
+# note: currently the first line must be left empty
+currency-editor-sign:
+  - ""
+  - "-----------"
+  - "Write the new value"
+  - "in the first line"
+
+# list of sounds: https://www.digminecraft.com/lists/sound_list_pc.php
+# set to "" to disable
+sounds:
+  # trade sounds
+  started: "entity.player.levelup"
+  completed: "entity.player.levelup"
+  aborted: "block.anvil.destroy"
+  # trade requests
+  deny: "block.anvil.land"
+  requested: "entity.experience_bottle.throw"
+  # gui sounds
+  accept: "ui.button.click"
+  countdown: "ui.button.click"
+  cancel: "ui.button.click"
+
+# can be used in the gui title as %own-status% and %partner-status%
+placeholders:
+  ready: "Ready"
+  waiting: "Waiting"
+
+commands:
+  invalid-value: "&#FF0000Invalid parameter: &#BB0000%value%"
+  invalid-command: "&#FF0000Invalid command or subcommand!"
+  missing-argument: "&#FF0000Missing argument! You must specify a value for &#BB0000%value%&#FF0000."
+  no-permission: "&#FF0000You don't have permission to access this command!"
+  out-of-range: "&#FF0000The &#BB0000%number% &#FF0000must be between &#BB0000%min% &#FF0000and &#BB0000%max%&#FF0000!"
+  player-only: "&#FF0000You must be a player to use this command!"
+  invalid-player: "&#FF0000The player &#BB0000%player% &#FF0000can not be found!"
+  invalid-selector: "&#FF0000You can not use this selector in this command!"
+
+update-notifier: "&#AAFFCCThere is a new version of the plugin available! &#DDDDDD(&#FFFFFFcurrent: &#FF0000%current% &#DDDDDD| &#FFFFFFlatest: &#00FF00%latest%&#DDDDDD)"
+safety: "&#FF0000This feature has been disabled for safety reasons and updating the plugin is required, please contact the server administrators."
+
+# do not change this
+version: 9

--- a/src/main/resources/lang/zh_cn/guis.yml
+++ b/src/main/resources/lang/zh_cn/guis.yml
@@ -1,0 +1,145 @@
+# DOCUMENTATION: https://docs.artillex-studios.com/axtrade.html
+# ITEM BUILDER: https://docs.artillex-studios.com/item-builder.html
+# Simplified Chinese translation by TendoArisu
+
+# ----- SETTINGS -----
+
+title: "&0正在与 %player% 交易"
+# a gui can have 1-6 rows
+rows: 6
+
+# ----- SLOTS -----
+
+# the slots where the items can be placed
+# make sure to not put decorative items or currency items in the these slots
+# the own-slots and partner-slots must have an equal amount of slots
+own-slots:
+  - 9-12
+  - 18-21
+  - 27-30
+  - 36-39
+  - 45-48
+
+partner-slots:
+  - 14-17
+  - 23-26
+  - 32-35
+  - 41-44
+  - 50-53
+
+# ----- ITEMS -----
+
+# items on your side
+own:
+  confirm-item:
+    slot: 0
+    # you can use these placeholders:
+    # %own-name%"
+    # %partner-name%
+    accept:
+      material: "RED_CONCRETE"
+      # if you want, you can add head textures, like this:
+      #material: "PLAYER_HEAD"
+      #texture: "%own-head%"
+      name: "&#00ffdd&l确认交易"
+      lore:
+        - ""
+        - " &7- &f你对这次交易满意吗？"
+        - ""
+        - "&#00ffdd&l> &#00ffdd点击 &8- &#00ffdd确认交易"
+    cancel:
+      material: "LIME_CONCRETE"
+      name: "&#00ffdd&l取消确认"
+      lore:
+        - ""
+        - " &7- &f你想修改交易内容吗？"
+        - ""
+        - "&#00ffdd&l> &#00ffdd点击 &8- &#00ffdd取消确认"
+  # you can define as many currencies as you want, but make sure to copy them to the 'partner' section too!
+  currency1:
+    slot: 2
+    # you need Vault installed for this
+    currency: "Vault"
+    material: "GOLD_NUGGET"
+    name: "&#00ffdd&l金币"
+    # you can use these placeholders:
+    #  %amount% (the amount the player set)
+    #  %tax-amount% (amount after tax)
+    #  %tax-percent% (the % of tax on the currency)
+    #  %tax-fee% (amount taken because of tax)
+    lore:
+      - "&7你的出价"
+      - ""
+      - " &7- &f数量：&#00ffdd%amount%$"
+      - ""
+      - "&#00ffdd&l> &#00ffdd点击 &8- &#00ffdd修改数量"
+  currency2:
+    slot: 3
+    currency: "Experience"
+    material: "EXPERIENCE_BOTTLE"
+    name: "&#00ffdd&l经验"
+    lore:
+      - "&7你的出价"
+      - ""
+      - " &7- &f数量：&#00ffdd%amount% EXP"
+      - ""
+      - "&#00ffdd&l> &#00ffdd点击 &8- &#00ffdd修改数量"
+
+# items on your trade partner's side
+partner:
+  confirm-item:
+    slot: 8
+    # you can also use these placeholders:
+    # %own-name%"
+    # %partner-name%
+    accept:
+      material: "RED_CONCRETE"
+      # if you want, you can add head textures, like this:
+      #material: "PLAYER_HEAD"
+      #texture: "%partner-head%"
+      name: "&#00ffdd&l等待对方确认"
+      lore:
+        - ""
+        - " &7- &f%partner-name% 尚未确认交易！"
+        - ""
+    cancel:
+      material: "LIME_CONCRETE"
+      name: "&#00ffdd&l对方已确认"
+      lore:
+        - ""
+        - " &7- &f%partner-name% 已确认交易！"
+  currency1:
+    slot: 6
+    currency: "Vault"
+    material: "GOLD_NUGGET"
+    name: "&#00ffdd&l金币"
+    # you can use these placeholders:
+    #  %amount% (the amount the player set)
+    #  %tax-amount% (amount after tax)
+    #  %tax-percent% (the % of tax on the currency)
+    #  %tax-fee% (amount taken because of tax)
+    lore:
+      - "&7%partner-name% 的出价"
+      - ""
+      - " &7- &f数量：&#00ffdd%amount%$"
+      - ""
+      - "&#00ffdd&l> &#00ffdd点击 &8- &#00ffdd修改数量"
+  currency2:
+    slot: 5
+    currency: "Experience"
+    material: "EXPERIENCE_BOTTLE"
+    name: "&#00ffdd&l经验"
+    lore:
+      - "&7%partner-name% 的出价"
+      - ""
+      - " &7- &f数量：&#00ffdd%amount% EXP"
+      - ""
+      - "&#00ffdd&l> &#00ffdd点击 &8- &#00ffdd修改数量"
+
+decoration-example:
+  slot: [4, 13, 22, 31, 40, 49]
+  material: "LIGHT_BLUE_STAINED_GLASS_PANE"
+  name: " "
+
+# do not change this
+version: 1

--- a/src/main/resources/lang/zh_cn/lang.yml
+++ b/src/main/resources/lang/zh_cn/lang.yml
@@ -1,0 +1,120 @@
+# DOCUMENTATION: https://docs.artillex-studios.com/axtrade.html
+# Simplified Chinese translation by TendoArisu
+
+player-help:
+  - " "
+  - "<gradient:#00FFDD:#55FFFF><b>AxTrade</b></gradient> <#22FFDD>帮助"
+  - " <#22FFDD>- <white>/axtrade <player> <#DDDDDD>| <#77FFFF>发送交易请求"
+  - " <#22FFDD>- <white>/axtrade accept <player> <#DDDDDD>| <#77FFFF>接受交易请求"
+  - " <#22FFDD>- <white>/axtrade deny <player> <#DDDDDD>| <#77FFFF>拒绝交易请求"
+  - " "
+
+admin-help:
+  - " "
+  - "<gradient:#00FFDD:#55FFFF><b>AxTrade</b></gradient> <#22FFDD>帮助"
+  - " <#22FFDD>- <white>/axtrade <player> <#DDDDDD>| <#77FFFF>发送交易请求"
+  - " <#22FFDD>- <white>/axtrade accept <player> <#DDDDDD>| <#77FFFF>接受交易请求"
+  - " <#22FFDD>- <white>/axtrade deny <player> <#DDDDDD>| <#77FFFF>拒绝交易请求"
+  - " <#22FFDD>- <white>/axtrade reload <#DDDDDD>| <#77FFFF>重载插件"
+  - " <#22FFDD>- <white>/axtrade force <player> <#DDDDDD>| <#77FFFF>强制开始交易"
+  - " <#22FFDD>- <white>/axtrade preview <#DDDDDD>| <#77FFFF>打开只读 GUI（用于测试）"
+  - " "
+
+reload:
+  success: "&#33FF33插件已成功重载！"
+  failed: "&#FF3333插件重载失败！&f%file%&#FF3333 文件存在问题，请查看控制台或使用 YAML 校验器修复错误！"
+
+trade:
+  started: "&#CCFFEE你已与 &#00FFDD%player% &#CCFFEE开始交易！"
+  completed: "&#CCFFEE你与 &#00FFDD%player% &#CCFFEE的交易已完成！"
+  aborted: "&#CCFFEE你与 &#00FFDD%player% &#CCFFEE的交易已取消！"
+  blacklisted-item: "&#CCFFEE该物品禁止交易！"
+  inventory-full: "&#CCFFEE你的交易对象没有更多空位，无法继续向交易界面放入物品。"
+  preview-info: "&#CCFFEE你正在打开预览 GUI。它仅用于测试配置，点击按钮可能会报错或无法正常工作。"
+
+toggle:
+  enabled: "&#CCFFEE你已开启交易请求！"
+  disabled: "&#CCFFEE你已关闭交易请求！"
+
+# summary after a successful trade
+summary:
+  get:
+    item: "&#00FF00&l+ &#00FF00%amount%x %item%"
+    currency: "&#00FF00&l+ &#00FF00%amount% %currency%"
+  give:
+    item: "&#FF0000&l- &#FF0000%amount%x %item%"
+    currency: "&#FF0000&l- &#FF0000%amount% %currency%"
+
+currency-editor:
+  success: "&#CCFFEE数值已成功修改！"
+  failed: "&#CCFFEE数值无效！"
+  not-enough: "&#CCFFEE你的该货币余额不足！"
+
+request:
+  sent-sender: "&#CCFFEE你已成功向 &#00FFDD%player% &#CCFFEE发送交易请求！"
+  sent-receiver:
+    info: "&#CCFFEE你收到了来自 &#00FFDD%player% &#CCFFEE的交易请求！"
+    accept:
+      message: "&#00FF00/trade accept %player%"
+      hover: "&#00FF00点击此处&n接受&#00FF00交易请求！"
+    deny:
+      message: "&#FF0000/trade deny %player%"
+      hover: "&#FF0000点击此处&n拒绝&#FF0000交易请求！"
+  no-request: "&#CCFFEE你没有来自 &#00FFDD%player% &#CCFFEE的待处理交易请求！"
+  deny-sender: "&#CCFFEE你的交易请求已被 &#00FFDD%player% &#CCFFEE拒绝！"
+  deny-receiver: "&#CCFFEE你已成功拒绝 &#00FFDD%player% &#CCFFEE的交易请求！"
+  cant-trade-self: "&#CCFFEE你不能向自己发送交易请求！"
+  already-in-trade: "&#CCFFEE该玩家已经在与其他人交易！"
+  already-sent: "&#CCFFEE你最近已经向 &#00FFDD%player% &#CCFFEE发送过交易请求！"
+  too-far: "&#CCFFEE你距离 &#00FFDD%player% &#CCFFEE太远，无法发送交易请求！"
+  not-accepting: "&#CCFFEE该玩家当前不接受交易！"
+  disallowed-gamemode: "&#CCFFEE你或对方处于禁止交易的游戏模式！"
+  same-ip: "&#CCFFEE你不能与和你 IP 相同的账号交易！"
+  below-required-amount: "&#CCFFEE本次交易至少需要包含 &f%amount% %currency%&#CCFFEE！"
+  blacklisted-world: "&#CCFFEE此世界已禁用交易！"
+  expired: "&#CCFFEE你发送给 &#00FFDD%player% &#CCFFEE的交易请求已过期！"
+  disabled-trading: "&#CCFFEE你已关闭交易！使用 &#00FFDD/trade toggle &#CCFFEE开启。"
+
+# this must be 4 lines
+# note: currently the first line must be left empty
+currency-editor-sign:
+  - ""
+  - "-----------"
+  - "在第一行输入"
+  - "新的数值"
+
+# list of sounds: https://www.digminecraft.com/lists/sound_list_pc.php
+# set to "" to disable
+sounds:
+  # trade sounds
+  started: "entity.player.levelup"
+  completed: "entity.player.levelup"
+  aborted: "block.anvil.destroy"
+  # trade requests
+  deny: "block.anvil.land"
+  requested: "entity.experience_bottle.throw"
+  # gui sounds
+  accept: "ui.button.click"
+  countdown: "ui.button.click"
+  cancel: "ui.button.click"
+
+# can be used in the gui title as %own-status% and %partner-status%
+placeholders:
+  ready: "已确认"
+  waiting: "等待中"
+
+commands:
+  invalid-value: "&#FF0000无效参数：&#BB0000%value%"
+  invalid-command: "&#FF0000无效的命令或子命令！"
+  missing-argument: "&#FF0000缺少参数！你必须为 &#BB0000%value% &#FF0000指定一个值。"
+  no-permission: "&#FF0000你没有权限使用该命令！"
+  out-of-range: "&#FF0000数值 &#BB0000%number% &#FF0000必须介于 &#BB0000%min% &#FF0000和 &#BB0000%max% &#FF0000之间！"
+  player-only: "&#FF0000你必须是玩家才能使用该命令！"
+  invalid-player: "&#FF0000找不到玩家 &#BB0000%player%&#FF0000！"
+  invalid-selector: "&#FF0000你不能在该命令中使用此选择器！"
+
+update-notifier: "&#AAFFCC插件有新版本可用！&#DDDDDD（&#FFFFFF当前：&#FF0000%current% &#DDDDDD| &#FFFFFF最新：&#00FF00%latest%&#DDDDDD）"
+safety: "&#FF0000出于安全原因，该功能已被禁用，并且需要更新插件。请联系服务器管理员。"
+
+# do not change this
+version: 9


### PR DESCRIPTION
This adds Simplified Chinese support and changes language loading so the configured `language` value selects files from a locale-specific `lang/<locale>/` folder. Existing root `lang.yml` and `guis.yml` files are migrated for `en_US` compatibility, while other languages can be switched to directly through config. Reloading now also refreshes the selected language files and command locale.